### PR TITLE
docs: clarify attention mass vs causal attribution

### DIFF
--- a/docs/visual-mapping.md
+++ b/docs/visual-mapping.md
@@ -61,3 +61,14 @@ geometry, highlighting the chapter's component. The Tokenizer, Embedding, and
 Self-Attention chapters keep their dedicated districts because those render
 **genuinely computed per-token data** (real PCA of hidden states, real attention
 weights) — richer than generic geometry, and not something to replace with it.
+
+## Causality Warning
+
+Attention mass is an interpretability signal, not proof of causal necessity.
+A token receiving high attention may be strongly attended to without being
+necessary for the model's output. Conversely, a token with lower attention
+may still affect the output through other parts of the computation.
+
+Therefore, the attention visualizations shown here describe how attention is
+distributed, but they should not be interpreted as causal evidence that a
+token was required for a particular model decision.


### PR DESCRIPTION
<!-- Thanks for contributing to TokenPrint! -->

## What & why

Clarifies the distinction between attention mass and causal necessity in the visual mapping documentation. High attention to a token should not be interpreted as proof that the token was causally necessary for the model's output.

Closes #96

## Type of change

* [ ] `feat` — new capability
* [ ] `fix` — bug fix
* [x] `docs` — documentation only
* [ ] `chore` / `refactor` / `perf` / `test`

## The "is it real?" checklist

TokenPrint's rule: every value shown is derived from real model data or a real
forward pass.

* [x] No hardcoded/placeholder numbers are presented as real model data.
* [x] If real data can't support a visual, it's labeled or adjusted (not faked).
* [x] Bounded payloads preserved (top-k not full vocab, weight slices not full
  matrices, sampled point clouds).

## Verification

* [ ] `cd frontend && npm run build` passes (type-checks the tree).
* [ ] Relevant backend script(s) green (`verify_real_data.py` / `verify_trace.py`
  / `verify_geometry.py`).
* [ ] If it touches the GGUF parser, verified against a real `.gguf` (state which
  model/architecture).
* [ ] If it changes a visual, attach a screenshot.

For this documentation-only change, no frontend build or backend verification
scripts were run because application logic, model data handling, and rendering
were not modified.

`git diff --check` passes with no whitespace errors.

## Screenshots (if UI)

Not applicable — documentation-only change.

## Notes for reviewers

Added a new **Causality Warning** section to `docs/visual-mapping.md` explaining
that attention mass is an interpretability signal and should not be treated as
evidence of causal necessity.