### PR TITLE
fix(ui): separate real and proxy per-layer timing in TimingReadout (ENG-15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,12 @@ We would rather under-claim than overstate. Known gaps, stated plainly:
 - **Quantized GGUF Backend Instrumentation:** Real quantized GGUF inference is supported via `llama.cpp` (`llama-cpp-python`). When executing via GGUF, tokens and top-k probabilities come directly from the quantized model; per-layer internal activations are not exposed by `llama.cpp`, so layer lighting is cleanly disabled to maintain data honesty.
 - The **live PyTorch model is Qwen** (real, loaded); GPT-2's formula set is wired and
   selected by architecture but not run locally.
-- **`TimingReadout` does not report real time.** It currently derives a proxy from PCA-space
-  hidden-state magnitudes and labels it in milliseconds — this is a known bug
-  ([#18](https://github.com/Sudharsanselvaraj/Token-Print/issues/18)), not a measurement.
+- **Per-layer timings are host wall-clock.** `TimingReadout` shows real ms (`REAL MS`) from
+  per-layer `perf_counter()` hooks on live PyTorch generations. No device synchronize is
+  issued, so on MPS/CUDA a layer's time can reflect when its work was queued rather than when
+  it finished. Traces recorded without timings fall back to mean |activation| per layer,
+  badged `PROXY · NOT MS` and never shown in milliseconds
+  ([#101](https://github.com/Sudharsanselvaraj/Token-Print/issues/101)).
 - **`ActivationPatchCompare` shows a logit-lens trajectory, not activation patching.** The
   numbers are real; the panel title overstates the method
   ([#75](https://github.com/Sudharsanselvaraj/Token-Print/issues/75)).

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -140,10 +140,11 @@ the rule is enforced by the build rather than by discipline.
 Honesty requires listing where the claim does not yet fully hold. These are
 tracked bugs, not accepted behaviour:
 
-- **`TimingReadout`** derives a proxy from PCA-space hidden-state magnitudes and
-  labels it in milliseconds. A PCA norm is dimensionless and unrelated to elapsed
-  time. Real per-layer timings need `perf_counter()` deltas on the streamed
-  frames — [#18](https://github.com/Sudharsanselvaraj/Token-Print/issues/18).
+- **`TimingReadout`** shows real per-layer `perf_counter()` deltas (`REAL MS`), but
+  no device synchronize is issued, so on MPS/CUDA they are host-side times. Traces
+  without timings fall back to mean |activation| per layer, badged
+  `PROXY · NOT MS` and never shown in milliseconds —
+  [#101](https://github.com/Sudharsanselvaraj/Token-Print/issues/101).
 - **`ActivationPatchCompare`** now shows a real logit-lens trajectory, but the
   panel is still titled "Activation Patching" — a stronger causal claim than the
   experiment performed — [#75](https://github.com/Sudharsanselvaraj/Token-Print/issues/75).

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2254,6 +2254,12 @@ code {
   color: var(--muted);
   margin-bottom: 6px;
 }
+.tp-note {
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--muted);
+  margin: 4px 0 6px;
+}
 .tp-bars {
   display: flex;
   flex-direction: column;

--- a/frontend/components/ui/TimingReadout.tsx
+++ b/frontend/components/ui/TimingReadout.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { useStore } from "@/lib/store";
+import { layerTimingView } from "@/lib/timing";
 import { useMemo } from "react";
-
-/**
- * Per-layer timing readout (issue #18).
- *
- * When a live generation is running (or a trace is playing), we show the real
- * ms-per-layer timings captured by the backend's per-layer forward hooks. If no
- * generation has run yet, we fall back to the debug snapshot's reported
- * timings (debug_timings), then to coarse simulated bars so the card is never
- * a dead end.
- */
 import DataProvenanceBadge from "./DataProvenanceBadge";
 
+/**
+ * Per-layer timing readout (issues #18, #101).
+ *
+ * Live generations carry real ms-per-layer timings captured by the backend's
+ * per-layer forward hooks. Traces recorded without them fall back to a proxy —
+ * mean |activation| per layer — which is unitless and never labelled as ms.
+ */
 export default function TimingReadout() {
   const genFrames = useStore((s) => s.genFrames);
   const genMeta = useStore((s) => s.genMeta);
@@ -23,30 +21,16 @@ export default function TimingReadout() {
   // Pick the frame currently on screen (during playback it's playIndex).
   const visibleIdx = isPlaying || playIndex >= 0 ? playIndex : genFrames.length - 1;
   const frame = genFrames[visibleIdx] ?? null;
+  const lastFrame = genFrames[genFrames.length - 1] ?? null;
 
-  const realTimings = useMemo(() => {
-    if (!frame?.layer_timings_ms?.length) return null;
-    const total = frame.layer_timings_ms.reduce((a, b) => a + b, 0);
-    const max = Math.max(...frame.layer_timings_ms, 1);
-    return { perLayer: frame.layer_timings_ms, total, max };
-  }, [frame]);
+  const view = useMemo(
+    () => layerTimingView(frame, lastFrame, genMeta?.num_layers),
+    [frame, lastFrame, genMeta],
+  );
 
-  const proxyTimings = useMemo(() => {
-    if (!genFrames.length || !genMeta?.num_layers) return null;
-    // No real timing payload (older trace) — derive a rough proxy from the
-    // layer_stats norm so older v0.2 traces still render something.
-    const nLayers = genMeta.num_layers;
-    const stats = frame?.layer_stats ?? genFrames[genFrames.length - 1]?.layer_stats;
-    if (!stats?.length) return null;
-    const perLayer = stats.slice(0, nLayers).map((s) => Math.max(s * 2.0, 0.05));
-    const total = perLayer.reduce((a, b) => a + b, 0);
-    const max = Math.max(...perLayer, 1);
-    return { perLayer, total, max };
-  }, [genFrames, frame, genMeta]);
+  if (!view) return null;
 
-  if (!realTimings && !proxyTimings) return null;
-
-  const data = realTimings ?? proxyTimings!;
+  const isReal = view.kind === "real";
 
   return (
     <div className="timing-panel">
@@ -54,32 +38,40 @@ export default function TimingReadout() {
         <span>
           Per-Layer Timing{" "}
           <DataProvenanceBadge
-            origin={realTimings ? "real" : "derived"}
-            label={realTimings ? "REAL MS" : "PROXY DERIVED"}
+            origin={isReal ? "real" : "simulation"}
+            label={isReal ? "REAL MS" : "PROXY · NOT MS"}
           />
         </span>
         {genMeta?.num_layers ? (
           <span className="tp-step">
-            step {frame?.step ?? 0} · {data.total.toFixed(2)}ms total
+            step {frame?.step ?? 0}
+            {view.total !== null ? ` · ${view.total.toFixed(2)}ms total` : null}
           </span>
         ) : null}
       </div>
+      {!isReal ? (
+        <div className="tp-note">
+          No timings in this trace — bars show mean |activation| per layer, not latency.
+        </div>
+      ) : null}
       <div className="tp-bars">
-        {data.perLayer.map((ms, i) => (
+        {view.perLayer.map((v, i) => (
           <div key={`${frame?.step ?? 0}-${i}`} className="tp-row">
             <span className="tp-label">L{i}</span>
             <div className="tp-bar-track">
               <div
                 className="tp-bar"
-                style={{ width: `${(ms / data.max) * 100}%` }}
+                style={{ width: `${(v / view.max) * 100}%` }}
               />
             </div>
-            <span className="tp-ms">{ms.toFixed(2)}</span>
+            <span className="tp-ms" title={isReal ? "ms" : "mean |activation| (unitless)"}>
+              {v.toFixed(2)}
+            </span>
           </div>
         ))}
       </div>
       <div className="tp-foot">
-        Total: {data.total.toFixed(2)}ms ·{" "}
+        {view.total !== null ? `Total: ${view.total.toFixed(2)}ms · ` : null}
         {genFrames.length} token{genFrames.length === 1 ? "" : "s"} recorded
       </div>
     </div>

--- a/frontend/lib/timing.ts
+++ b/frontend/lib/timing.ts
@@ -1,0 +1,53 @@
+import type { TokenFrame } from "./types";
+
+/**
+ * Per-layer timing view for the TimingReadout panel (issues #18, #101).
+ *
+ * - `real`  — wall-clock ms per layer, measured by the backend's per-layer
+ *             forward hooks (`frame.layer_timings_ms`).
+ * - `proxy` — the frame carries no timings (e.g. a trace recorded before they
+ *             existed), so we fall back to mean |activation| per layer from
+ *             `frame.layer_stats`. It is unitless and NOT a latency: `total`
+ *             is null so callers cannot render it as milliseconds.
+ */
+export type LayerTimingKind = "real" | "proxy";
+
+export interface LayerTimingView {
+  kind: LayerTimingKind;
+  perLayer: number[];
+  /** Sum of per-layer ms. Null for proxy — activation norms don't add up to a time. */
+  total: number | null;
+  /** Bar-scale denominator (> 0). */
+  max: number;
+}
+
+export function layerTimingView(
+  frame: TokenFrame | null,
+  fallbackFrame: TokenFrame | null,
+  numLayers: number | undefined,
+): LayerTimingView | null {
+  const timings = frame?.layer_timings_ms;
+  if (timings?.length) {
+    return {
+      kind: "real",
+      perLayer: timings,
+      total: timings.reduce((a, b) => a + b, 0),
+      // Bars scale to at least 1 ms so sub-ms layers don't all look "hot".
+      max: Math.max(...timings, 1),
+    };
+  }
+
+  if (!numLayers) return null;
+  const stats = frame?.layer_stats ?? fallbackFrame?.layer_stats;
+  if (!stats?.length) return null;
+  // Live frames build layer_stats from hidden_states: num_layers + 1 entries,
+  // entry 0 being the embedding output. Older traces may carry exactly
+  // num_layers. Taking the last num_layers keeps one value per layer for both.
+  const perLayer = stats.slice(-numLayers);
+  return {
+    kind: "proxy",
+    perLayer,
+    total: null,
+    max: Math.max(...perLayer, Number.MIN_VALUE),
+  };
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -36,5 +36,11 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      // Pure-logic unit tests in tests/unit/ — no browser, backend or dev
+      // server needed:  npx playwright test --project=unit
+      name: "unit",
+      testDir: "./tests/unit",
+    },
   ],
 });

--- a/frontend/tests/unit/timing.spec.ts
+++ b/frontend/tests/unit/timing.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+import { layerTimingView } from "../../lib/timing";
+import type { TokenFrame } from "../../lib/types";
+
+// Unit tests for the TimingReadout data selection (issue #101 / ENG-15).
+// Run: npx playwright test --project=unit
+
+function frame(overrides: Partial<TokenFrame> = {}): TokenFrame {
+  return {
+    type: "token",
+    step: 0,
+    chosen: { id: 0, text: "", logprob: 0 },
+    topk: [],
+    layer_stats: [],
+    eos: false,
+    ...overrides,
+  };
+}
+
+test.describe("layerTimingView — real timings", () => {
+  test("measured layer_timings_ms are reported as real ms", () => {
+    const view = layerTimingView(frame({ layer_timings_ms: [2, 5, 3] }), null, 3);
+    expect(view).toEqual({ kind: "real", perLayer: [2, 5, 3], total: 10, max: 5 });
+  });
+
+  test("real timings win over layer_stats when both are present", () => {
+    const f = frame({ layer_timings_ms: [1.5, 2.5], layer_stats: [9, 9, 9] });
+    expect(layerTimingView(f, null, 2)?.kind).toBe("real");
+  });
+
+  test("real timings don't need meta.num_layers", () => {
+    expect(layerTimingView(frame({ layer_timings_ms: [4] }), null, undefined)?.kind).toBe("real");
+  });
+
+  test("bar scale floors at 1 ms so sub-ms layers aren't drawn as full bars", () => {
+    const view = layerTimingView(frame({ layer_timings_ms: [0.2, 0.4] }), null, 2);
+    expect(view?.max).toBe(1);
+  });
+});
+
+test.describe("layerTimingView — proxy fallback", () => {
+  // Real backend shape: hidden_states → num_layers + 1 stats, entry 0 = embedding.
+  const stats = [7, 0.1, 0.3, 0.2];
+
+  test("missing layer_timings_ms falls back to proxy with no total", () => {
+    const view = layerTimingView(frame({ layer_stats: stats }), null, 3);
+    expect(view?.kind).toBe("proxy");
+    expect(view?.total).toBeNull();
+  });
+
+  test("empty layer_timings_ms also falls back to proxy", () => {
+    const view = layerTimingView(frame({ layer_stats: stats, layer_timings_ms: [] }), null, 3);
+    expect(view?.kind).toBe("proxy");
+  });
+
+  test("proxy drops the embedding entry so L0 is the first layer", () => {
+    const view = layerTimingView(frame({ layer_stats: stats }), null, 3);
+    expect(view?.perLayer).toEqual([0.1, 0.3, 0.2]);
+    expect(view?.perLayer).toHaveLength(3);
+  });
+
+  test("stats already one-per-layer (bundled demo trace shape) are kept whole", () => {
+    const view = layerTimingView(frame({ layer_stats: [0.1, 0.3, 0.2] }), null, 3);
+    expect(view?.perLayer).toEqual([0.1, 0.3, 0.2]);
+  });
+
+  test("proxy values are the raw activation stats, not rescaled", () => {
+    const view = layerTimingView(frame({ layer_stats: stats }), null, 3);
+    expect(view?.max).toBe(0.3);
+  });
+
+  test("no visible frame → uses the latest recorded frame's stats", () => {
+    const view = layerTimingView(null, frame({ layer_stats: stats }), 3);
+    expect(view?.perLayer).toEqual([0.1, 0.3, 0.2]);
+  });
+
+  test("all-zero stats keep a positive bar scale (no NaN widths)", () => {
+    const view = layerTimingView(frame({ layer_stats: [0, 0, 0] }), null, 2);
+    expect(view?.max).toBeGreaterThan(0);
+    expect(view!.perLayer.every((v) => Number.isFinite(v / view!.max))).toBe(true);
+  });
+});
+
+test.describe("layerTimingView — nothing to show", () => {
+  test("GGUF/llama.cpp frames (empty stats and timings) hide the panel", () => {
+    const f = frame({ layer_stats: [], layer_timings_ms: [], source: "llama.cpp" });
+    expect(layerTimingView(f, null, 24)).toBeNull();
+  });
+
+  test("no timings and no num_layers → null", () => {
+    expect(layerTimingView(frame({ layer_stats: [1, 2] }), null, undefined)).toBeNull();
+  });
+
+  test("no frames at all → null", () => {
+    expect(layerTimingView(null, null, 24)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

`TimingReadout` has two data paths: **real** per-layer latency measured by the backend's `perf_counter()` forward hooks (`frame.layer_timings_ms`), and a **fallback** for frames without timings (e.g. the bundled demo trace or older traces), which uses mean |activation| per layer (`layer_stats`).

The fallback was badged `PROXY DERIVED` but still rendered in **milliseconds** ("…ms total", "Total: …ms", and an ms column), so a unitless activation norm read as a latency. It also multiplied norms by an arbitrary 2.0 and sliced `layer_stats` from index 0, which is the embedding output. So the "L0" row was the embedding and the last layer was dropped.

This PR:
- Moves the selection into a pure `layerTimingView()` (`frontend/lib/timing.ts`) returning `{ kind: "real" | "proxy", perLayer, total, max }`. The proxy's `total` is `null`, so a proxy total can't be rendered as ms.
- **Real path:** unchanged. `REAL MS` badge, ms totals.
- **Proxy path:** the existing `DataProvenanceBadge` `simulation` origin labelled `PROXY · NOT MS` (the README says proxy values use SIMULATION), a one-line note, raw values, no ms units and no total.
- Drops the ×2.0 scale and 0.05 floor, and fixes the off-by-one. `slice(-numLayers)` handles both live `num_layers + 1` stats and older traces with exactly `num_layers`.
- Updates the README "Honest limitations" entry and `docs/verification.md`, which still said the readout never reports real time.
- Adds 14 unit tests (`frontend/tests/unit/timing.spec.ts`), run by a new `unit` project in `playwright.config.ts`. They reuse the existing `@playwright/test` dev dependency, so there are no new dependencies and no overlap with ENG-07 (Vitest).

Closes #101

## Type of change

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` / `refactor` / `perf` / `test`

## The "is it real?" checklist

TokenPrint's rule: every value shown is derived from real model data or a real
forward pass.

- [x] No hardcoded/placeholder numbers are presented as real model data.
- [x] If real data can't support a visual, it's labeled or adjusted (not faked).
- [x] Bounded payloads preserved (top-k not full vocab, weight slices not full
      matrices, sampled point clouds).

## Verification

- [x] `cd frontend && npm run build` passes (type-checks the tree). Also `npx tsc --noEmit` is clean and `npx playwright test --project=unit` gives **14 passed**.
- [ ] Relevant backend script(s) green (`verify_real_data.py` / `verify_trace.py`
      / `verify_geometry.py`). **N/A:** no backend changes. The backend was only run locally for the live-generation screenshot.
- [ ] If it touches the GGUF parser, verified against a real `.gguf` (state which
      model/architecture). **N/A:** parser untouched. GGUF frames (empty stats and timings) are covered by a unit test and still hide the panel.
- [x] If it changes a visual, attach a screenshot.

## Screenshots (if UI)

Bundled demo trace (`public/demo/hello-world.json`, no `layer_timings_ms`), Debugger → Layer Timing:

| Before: proxy shown as "3.83ms total", L0 = embedding | After: `PROXY · NOT MS`, no ms, L0–L23 = layers |
|---|---|
| <img width="362" alt="before-proxy" src="https://github.com/user-attachments/assets/599996c9-109e-4be5-9a92-6647173f3cd3" /> | <img width="362" alt="after-proxy" src="https://github.com/user-attachments/assets/9efc0873-fe82-4eda-b53d-20a915b18155" /> |

Live generation, Qwen2.5-0.5B-Instruct on Apple MPS (float32). The real path is unchanged:

<img width="362" alt="after-real" src="https://github.com/user-attachments/assets/f820f5d1-5877-4f17-85e7-9dbba7e94bc0" />

## Notes for reviewers

- **Issue wording vs code:** the issue mentions "PCA magnitude" and "profiling". The proxy is mean |activation| (not PCA), and there's no profiling toggle: real timings are always captured for the PyTorch backend. The proxy only appears for frames without `layer_timings_ms`.
- **`REAL MS` is host wall-clock.** No `torch.mps/cuda.synchronize()` is issued, so on a GPU a layer's time can reflect when its work was queued. Documented in the README. While testing on MPS, L0 reported ~1.1–1.5 s per step versus ~1–8 ms for L1–L23. This fits queued work surfacing at the first blocking layer, but I haven't verified the cause. Could be a follow-up (sync behind a profiling flag).
- **Pre-existing, left unchanged:** in the dev-mode overlay, `TimingReadout` and `DistributionPanel` share `left: 680px` and overlap. `backend/requirements.txt` is missing `python-multipart` (uvicorn won't start without it). Happy to open separate issues.
- **Lint:** `npm run lint` wasn't run. The repo has no ESLint config, so `next lint` prompts to create one.
