### PR TITLE
fix(backend): enforce GGUF upload size limit and cleanup (ENG-09)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,9 @@ _last_trace: dict | None = None
 GGUF_DIR = Path(__file__).resolve().parent.parent / "data" / "gguf"
 GGUF_DIR.mkdir(parents=True, exist_ok=True)
 
+# Hard upload limit for GGUF files (ENG-09). 10 GB expressed in bytes.
+MAX_GGUF_BYTES = 10 * 1024 * 1024 * 1024
+
 # Cache of opened GGUF engines keyed by resolved path.
 _gguf_engines: dict[str, GGUFEngine] = {}
 
@@ -257,10 +260,25 @@ async def gguf_upload(file: UploadFile = File(None)) -> dict:  # noqa: B008
     if not str(dest).startswith(str(base_dir) + os.sep):
         raise HTTPException(status_code=400, detail="Invalid target path.")
     size = 0
-    with open(dest, "wb") as fh:  # noqa: ASYNC230
-        while chunk := await file.read(1 << 20):
-            size += len(chunk)
-            fh.write(chunk)
+    try:
+        with open(dest, "wb") as fh:  # noqa: ASYNC230
+            while chunk := await file.read(8 << 20):  # 8 MB chunks
+                size += len(chunk)
+                if size > MAX_GGUF_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"Upload rejected: file exceeds the "
+                            f"{MAX_GGUF_BYTES // (1024 ** 3)} GB limit."
+                        ),
+                    )
+                fh.write(chunk)
+    except HTTPException:
+        dest.unlink(missing_ok=True)
+        raise
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
     return {"name": safe, "path": safe, "size_bytes": size, "quant": _quant_guess(safe)}
 
 

--- a/backend/tests/test_gguf_upload.py
+++ b/backend/tests/test_gguf_upload.py
@@ -1,0 +1,142 @@
+﻿"""Tests for GGUF upload size-limit enforcement and temp-file cleanup (ENG-09).
+
+These tests mock heavy native dependencies (torch, sklearn, llama_cpp) so they
+run without a GPU or PyTorch install.  The model lifespan is also stubbed so no
+model is downloaded.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest.mock as mock
+from io import BytesIO
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Pre-mock all native deps BEFORE importing anything from app.*
+# (same technique as test_rag_patching.py which adds backend to sys.path)
+# ---------------------------------------------------------------------------
+_HEAVY_MODS = [
+    "torch", "torch.nn", "torch.nn.functional",
+    "transformers", "transformers.modeling_outputs",
+    "llama_cpp",
+    "PIL", "PIL.Image",
+    "sklearn", "sklearn.decomposition",
+]
+for _mod in _HEAVY_MODS:
+    sys.modules.setdefault(_mod, mock.MagicMock())
+
+# Add backend directory to sys.path (matches existing test pattern).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from starlette.testclient import TestClient
+
+import app.main as main_module
+from app.main import GGUF_DIR, app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _upload_bytes(client: TestClient, data: bytes, filename: str = "model.gguf") -> object:
+    """POST `data` to /gguf/upload as a multipart file."""
+    return client.post(
+        "/gguf/upload",
+        files={"file": (filename, BytesIO(data), "application/octet-stream")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def client():
+    """TestClient with the model lifespan stubbed out (no PyTorch needed)."""
+    mock_engine = mock.MagicMock()
+    mock_engine.model_id = "test-model"
+    mock_engine.device = "cpu"
+    mock_engine.num_layers = 2
+    mock_engine.num_heads = 2
+    mock_engine.hidden_size = 16
+    mock_engine.mode = "text"
+    mock_engine.model_type = "gpt2"
+
+    with mock.patch.object(main_module, "ModelEngine", return_value=mock_engine):
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_gguf_dir():
+    """Remove any .gguf test artefacts from GGUF_DIR before and after each test."""
+    for p in GGUF_DIR.glob("*.gguf"):
+        p.unlink(missing_ok=True)
+    yield
+    for p in GGUF_DIR.glob("*.gguf"):
+        p.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGgufUploadSizeLimit:
+    """Size-limit enforcement and cleanup (ENG-09)."""
+
+    def test_oversized_upload_rejected_with_413(self, client: TestClient):
+        """Uploading a file larger than MAX_GGUF_BYTES returns HTTP 413."""
+        with mock.patch.object(main_module, "MAX_GGUF_BYTES", 10):
+            payload = b"X" * 20  # 20 bytes > 10-byte limit
+            resp = _upload_bytes(client, payload)
+
+        assert resp.status_code == 413, (
+            f"Expected 413, got {resp.status_code}: {resp.text}"
+        )
+        assert "limit" in resp.json()["detail"].lower()
+
+    def test_oversized_upload_leaves_no_temp_file(self, client: TestClient):
+        """A rejected oversized upload must not leave a partial file in GGUF_DIR."""
+        filename = "oversized_test.gguf"
+        dest = GGUF_DIR / filename
+
+        assert not dest.exists(), "Pre-condition: file must not exist before upload"
+
+        with mock.patch.object(main_module, "MAX_GGUF_BYTES", 10):
+            payload = b"X" * 20
+            resp = _upload_bytes(client, payload, filename=filename)
+
+        assert resp.status_code == 413
+        assert not dest.exists(), (
+            f"Partial temp file was left behind at {dest}"
+        )
+
+    def test_valid_upload_within_limit_succeeds(self, client: TestClient):
+        """A file within the limit is accepted, saved to GGUF_DIR, and returns 200."""
+        filename = "small_valid.gguf"
+        dest = GGUF_DIR / filename
+        payload = b"GGUF" + b"\x00" * 16  # tiny but named .gguf
+
+        resp = _upload_bytes(client, payload, filename=filename)
+
+        assert resp.status_code == 200, (
+            f"Expected 200, got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        assert body["name"] == filename
+        assert body["size_bytes"] == len(payload)
+        assert dest.exists(), "Uploaded file should exist in GGUF_DIR after success"
+
+    def test_valid_upload_file_persists_after_success(self, client: TestClient):
+        """The destination file is NOT deleted after a successful upload."""
+        filename = "persist_check.gguf"
+        dest = GGUF_DIR / filename
+        payload = b"GGUF" + b"\x00" * 8
+
+        resp = _upload_bytes(client, payload, filename=filename)
+        assert resp.status_code == 200
+        assert dest.exists()
+        assert dest.stat().st_size == len(payload)


### PR DESCRIPTION
## Summary

Enforces a hard 10 GB size limit on GGUF file uploads and guarantees that any
partially-written temp file is removed immediately when an upload is rejected or
fails for any reason.

Closes #105

## What Changed

**`backend/app/main.py`** — two modifications to `gguf_upload()` and one addition
at module level:

- Added module-level constant `MAX_GGUF_BYTES = 10 * 1024 * 1024 * 1024` (10 GB),
  co-located with the existing `GGUF_DIR` declaration.
- Replaced the bare `with open(dest, "wb")` write loop with a `try/except` block
  that checks the running byte total against `MAX_GGUF_BYTES` after every 8 MB chunk
  is read, raising HTTP 413 immediately if the limit is crossed.
- Both `except HTTPException` and `except Exception` branches call
  `dest.unlink(missing_ok=True)` before re-raising, ensuring the partial file is
  deleted in every error path.

**`backend/tests/test_gguf_upload.py`** — new test file (4 tests) covering the
size-limit rejection path and cleanup behaviour.

## Implementation

**Why the size check happens during streaming rather than trusting `Content-Length`**

`Content-Length` is an optional HTTP header that a client can omit entirely or
deliberately falsify. Trusting it alone would allow a malicious or misconfigured
client to bypass the limit by sending an incorrect (or missing) header while still
streaming gigabytes of data. Checking the accumulating `size` counter inside the
read loop enforces the limit on the actual bytes received, not on what the client
claimed.

**Why `try/except` (rather than `try/finally`) is used to guarantee cleanup**

A successful upload must *keep* the destination file — `finally` would delete it
unconditionally unless guarded by a success-flag variable, adding indirection.
Instead, two `except` clauses cover every early-exit path:

- `except HTTPException` — catches the 413 raised mid-stream when the limit is
  exceeded, unlinks the partial file, and re-raises so FastAPI returns the 413 to
  the client.
- `except Exception` — catches any other unexpected error (disk full, I/O error,
  etc.), unlinks the partial file, and re-raises so the server returns a 500.

On the normal success path neither clause is entered, so the file is preserved.

## Testing

**Automated tests** (`backend/tests/test_gguf_upload.py`):

```
cd backend
python -m pytest tests/test_gguf_upload.py -v
```

Output:
```
collected 4 items

tests/test_gguf_upload.py::TestGgufUploadSizeLimit::test_oversized_upload_rejected_with_413 PASSED
tests/test_gguf_upload.py::TestGgufUploadSizeLimit::test_oversized_upload_leaves_no_temp_file PASSED
tests/test_gguf_upload.py::TestGgufUploadSizeLimit::test_valid_upload_within_limit_succeeds PASSED
tests/test_gguf_upload.py::TestGgufUploadSizeLimit::test_valid_upload_file_persists_after_success PASSED

4 passed in 0.83s
```

**Manual verification** (run via an in-process Python script against the real
`TestClient`):

1. `MAX_GGUF_BYTES` temporarily patched to 1 024 bytes; a 2 048-byte payload was
   POSTed to `/gguf/upload` → **HTTP 413** returned, response body:
   `{"detail": "Upload rejected: file exceeds the 0 GB limit."}`.
2. The destination path (`backend/data/gguf/manual_verify.gguf`) was checked
   immediately after the 413 response → **file did not exist** (partial write
   cleaned up).
3. `MAX_GGUF_BYTES` reverted to `10 * 1024 * 1024 * 1024` (10 737 418 240 bytes);
   a 404-byte payload was POSTed → **HTTP 200**, file written to `GGUF_DIR`,
   response: `{"name": "normal_upload.gguf", "size_bytes": 404, ...}`.

## Screenshots

> A terminal log of the 413 rejection is available locally. Please attach a
> screenshot manually if required by the reviewer — the log lines to look for are:
> ```
> INFO:httpx:HTTP Request: POST http://testserver/gguf/upload "HTTP/1.1 413 Request Entity Too Large"
> ```

## Limitations / Notes

- **No periodic sweep for pre-existing orphaned temp files**: if a server process
  was killed mid-upload before this fix was applied, any files left behind are not
  automatically removed. A separate maintenance task would be needed for that.
- **CI does not run pytest**: the existing CI workflow (`ci.yml`) only byte-compiles
  and lints the backend; it does not execute `pytest`. The new test file is for
  local verification. Enabling pytest in CI is out of scope for this issue.
- **Size check is post-write-of-chunk**: the check fires *after* the current 8 MB
  chunk is accumulated in the counter but *before* it is written to disk when the
  total would exceed the limit. The maximum overshoot is one 8 MB chunk beyond the
  10 GB boundary, which is acceptable for this use-case and matches the instruction
  to "stop writing immediately" mid-stream.
