### PR TITLE
fix(ci): repair branch protection checks, pin ruff, auto-update contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
 
       - name: Lint (ruff)
         run: |
-          python -m pip install --quiet ruff
-          ruff check backend/app backend/scripts
+          python -m pip install --quiet ruff==0.16.7
+          ruff check backend/app backend/scripts backend/tests

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   review:
     name: Gemini PR review
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    if: github.actor != 'dependabot[bot]' && (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   triage:
     name: Gemini issue triage
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,71 @@
+name: "🧑‍🤝‍🧑 Update Contributors"
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Regenerate contributors table
+        id: update
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const { data: contributors } = await github.rest.repos.listContributors({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+              anon: false,
+            });
+
+            const rows = contributors
+              .filter((c) => c.type === 'User' && !c.login.endsWith('[bot]'))
+              .map((c) =>
+                `| [![${c.login}](https://github.com/${c.login}.png?size=48)]` +
+                `(https://github.com/${c.login}) | [${c.login}]` +
+                `(https://github.com/${c.login}) | ${c.contributions} |`
+              )
+              .join('\n');
+
+            const start = '<!-- CONTRIBUTORS:START -->';
+            const end = '<!-- CONTRIBUTORS:END -->';
+            const block = `${start}\n${rows}\n${end}`;
+
+            let readme = fs.readFileSync('README.md', 'utf8');
+            if (!readme.includes(start)) {
+              console.log('Contributors markers not found in README.md; skipping update.');
+              return;
+            }
+
+            const next = readme.replace(new RegExp(`${start}[\\s\\S]*?${end}`), block);
+            if (next === readme) {
+              console.log('README contributors table unchanged; nothing to commit.');
+              return;
+            }
+
+            fs.writeFileSync('README.md', next);
+            console.log('README.md updated with fresh contributor list.');
+
+      - name: Commit and push if changed
+        run: |
+          if [ -n "$(git status --porcelain README.md)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add README.md
+            git commit -m "chore: auto-update contributors in README"
+            git push
+          else
+            echo "No README changes to commit."
+          fi

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   welcome:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/first-interaction@v1

--- a/README.md
+++ b/README.md
@@ -312,15 +312,14 @@ TokenPrint was designed and built from the ground up by **[Sudharsan Selvaraj](h
 
 ### Contributors
 
-Everyone below has a merged pull request in TokenPrint — code, docs, bug fixes, or design. This grid updates automatically as new contributions land.
+Everyone below has a merged pull request in TokenPrint — code, docs, bug fixes, or design. This table is regenerated automatically on every merge to `main` by the [Update Contributors](.github/workflows/update-contributors.yml) workflow.
 
-<p align="left">
-  <a href="https://github.com/Sudharsanselvaraj/Token-Print/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=Sudharsanselvaraj/Token-Print" alt="TokenPrint contributors" />
-  </a>
-</p>
+<!-- CONTRIBUTORS:START -->
+| Avatar | Contributor | Merged PRs |
+|---|---|---|
+| <!-- CONTRIBUTORS:END -->
 
-Want to be in that grid? Grab one of the **26 curated issues** in [GOOD_FIRST_ISSUES.md](GOOD_FIRST_ISSUES.md),
+Want to be in that table? Grab one of the **26 curated issues** in [GOOD_FIRST_ISSUES.md](GOOD_FIRST_ISSUES.md),
 read [CONTRIBUTING.md](CONTRIBUTING.md) to get set up, and open a PR. First-time open-source
 contributors are very welcome.
 

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -570,19 +570,16 @@ class ModelEngine:
 
         for info in addr_info:
             ip_str = info[4][0]
-            try:
-                ip = ipaddress.ip_address(ip_str)
-                if (
-                    ip.is_loopback
-                    or ip.is_private
-                    or ip.is_link_local
-                    or ip.is_multicast
-                    or ip.is_reserved
-                    or ip.is_unspecified
-                ):
-                    raise ValueError(f"Access to internal IP address '{ip_str}' is forbidden.")
-            except ValueError:
-                raise
+            ip = ipaddress.ip_address(ip_str)
+            if (
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+                or ip.is_unspecified
+            ):
+                raise ValueError(f"Access to internal IP address '{ip_str}' is forbidden.")
 
     @staticmethod
     def _load_image_bytes(image: str) -> torch.Tensor | bytes:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -10,8 +10,8 @@ Tests cover:
 """
 
 import sys
-import unittest.mock as mock
 from pathlib import Path
+from unittest import mock
 
 # Add backend directory to sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -24,7 +24,6 @@ for _mod in _HEAVY_MODS:
     if _mod not in sys.modules:
         sys.modules[_mod] = mock.MagicMock()
 
-import pytest
 from fastapi.testclient import TestClient
 
 # Mock ModelEngine before importing app.main so engine is populated

--- a/backend/tests/test_backend_suite.py
+++ b/backend/tests/test_backend_suite.py
@@ -23,7 +23,7 @@ from app.reduce import (
     query_self_attribution,
     ungrounded_flags,
 )
-from app.schemas import AnalyzeRequest, ModelInfo, RagAnalyzeRequest, RagChunk
+from app.schemas import AnalyzeRequest, RagAnalyzeRequest, RagChunk
 
 
 def test_project_3d_standard_shape():

--- a/backend/tests/test_gguf_upload.py
+++ b/backend/tests/test_gguf_upload.py
@@ -8,10 +8,9 @@ model is downloaded.
 from __future__ import annotations
 
 import sys
-import types
-import unittest.mock as mock
 from io import BytesIO
 from pathlib import Path
+from unittest import mock
 
 # ---------------------------------------------------------------------------
 # Pre-mock all native deps BEFORE importing anything from app.*
@@ -30,12 +29,10 @@ for _mod in _HEAVY_MODS:
 # Add backend directory to sys.path (matches existing test pattern).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import pytest
-from starlette.testclient import TestClient
-
 import app.main as main_module
+import pytest
 from app.main import GGUF_DIR, app
-
+from starlette.testclient import TestClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,9 +62,8 @@ def client():
     mock_engine.mode = "text"
     mock_engine.model_type = "gpt2"
 
-    with mock.patch.object(main_module, "ModelEngine", return_value=mock_engine):
-        with TestClient(app) as c:
-            yield c
+    with mock.patch.object(main_module, "ModelEngine", return_value=mock_engine), TestClient(app) as c:
+        yield c
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_hf_lookup.py
+++ b/backend/tests/test_hf_lookup.py
@@ -1,8 +1,8 @@
 """Unit tests for remote Hugging Face model lookup restriction & caching (ENG-11)."""
 
 import sys
-import unittest.mock as mock
 from pathlib import Path
+from unittest import mock
 
 # Add backend directory to sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -62,7 +62,7 @@ def test_cached_checkpoint_architecture():
 
     with mock.patch("transformers.AutoConfig.from_pretrained", return_value=mock_config) as mock_from_pretrained:
         res1 = ModelEngine.checkpoint_architecture("test-org/dummy-model")
-        res2 = ModelEngine.checkpoint_architecture("test-org/dummy-model")
+        ModelEngine.checkpoint_architecture("test-org/dummy-model")
 
         assert res1["model"] == "test-org/dummy-model"
         assert res1["metadata"]["num_layers"] == 24

--- a/backend/tests/test_rag_patching.py
+++ b/backend/tests/test_rag_patching.py
@@ -10,10 +10,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 import torch
-import torch.nn as nn
-
 from app.ablation import ActivationPatch, PositionActivationPatch
 from app.reduce import causal_chunk_scores
+from torch import nn
 
 
 class DummyLayer(nn.Module):
@@ -74,10 +73,9 @@ def test_position_aware_zero_knockout():
     with patch:
         # Pre-hook on layer 1 intercepts layer input
         # We trace what layer 1 receives by testing forward hook on dummy model
-        out = model(inputs_embeds=input_tensor.clone())
+        model(inputs_embeds=input_tensor.clone())
 
     # Test the hook directly on an input tensor
-    hooks = []
     layer_inputs = []
     def record_in(_mod, args):
         layer_inputs.append(args[0].clone())

--- a/backend/tests/test_ssrf.py
+++ b/backend/tests/test_ssrf.py
@@ -1,8 +1,8 @@
 """Unit tests for SSRF protection in remote image loading (ENG-10)."""
 
 import sys
-import unittest.mock as mock
 from pathlib import Path
+from unittest import mock
 
 # Add backend directory to sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## What & why
The branch protection on `main` required two status checks that **no workflow can ever produce** — `Backend · compile & lint` (the real job is `Backend · syntax & lint`) and `Gemini PR Quality Gate` (a commit status that is never created). Result: no contributor PR can satisfy the required checks. This PR fixes the pipeline.

## Changes
- **Branch protection** (applied directly, not in this diff): required checks are now `Frontend · type-check & build` + `Backend · syntax & lint`.
- **fix `ruff TRY203` in `backend/app/model.py`** — the redundant `try/except ValueError: raise` (from the SSRF PR) was failing the Backend lint job on `main` and on every PR.
- **Pin `ruff==0.16.7`** in `ci.yml` so newly-released lint rules can't silently break CI, and **lint `backend/tests`** too.
- **Lint hygiene in `backend/tests/*`** (import style/ordering, unused locals) — fixes the CodeQL unused-import alerts on contributor PRs.
- **Dependabot guards** in `gemini-review`, `gemini-triage`, and `welcome` workflows to stop noisy failures on Dependabot PRs.
- **`update-contributors.yml`** — regenerates the README contributor table on every merge to `main`.

## Verification
- `ruff check backend/app backend/scripts backend/tests` (0.16.7): all passed.
- `python -m compileall backend/app backend/scripts`: passed.
- `pytest backend/tests/test_hf_lookup.py test_ssrf.py test_rag_patching.py test_schemas.py`: 16 passed (2 unrelated cross-file mock failures are pre-existing on main and do not reproduce standalone).