### PR TITLE
Feat/rebrand neuroscope to tokenprint

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-"""NeuroScope backend — FastAPI service serving REAL language-model internals.
+"""TokenPrint backend — FastAPI service serving REAL language-model internals.
 
 Every value this package emits (attention weights, hidden-state stats, logits)
 comes from an actual forward pass of a real open-weight model. Nothing here is

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-"""FastAPI application for NeuroScope.
+"""FastAPI application for TokenPrint.
 
 Endpoints:
   * GET  /health      — liveness + whether the model is loaded
@@ -50,7 +50,7 @@ from .schemas import (
 from .trace import TraceRecorder, parse_trace, serialize_trace
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("neuroscope")
+logger = logging.getLogger("tokenprint")
 
 # Single process-wide engine handle, populated in the lifespan handler.
 engine: ModelEngine | None = None
@@ -105,7 +105,7 @@ async def lifespan(app: FastAPI):
     engine = None
 
 
-app = FastAPI(title="NeuroScope", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="TokenPrint", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -46,12 +46,8 @@ from transformers import (
 from .debug import DebugCapture
 from .reduce import explained_variance, project_3d
 
-DEFAULT_MODEL_ID = os.environ.get(
-    "TOKENPRINT_MODEL", os.environ.get("NEUROSCOPE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
-)
-MAX_TOKENS = int(
-    os.environ.get("TOKENPRINT_MAX_TOKENS", os.environ.get("NEUROSCOPE_MAX_TOKENS", "40"))
-)
+DEFAULT_MODEL_ID = os.environ.get("TOKENPRINT_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+MAX_TOKENS = int(os.environ.get("TOKENPRINT_MAX_TOKENS", "40"))
 
 # Rounding / thresholding for the attention payload.
 _ATTN_DECIMALS = 3
@@ -92,7 +88,7 @@ def _classify_model_type(model_type: str) -> str:
 
 def _pick_device() -> str:
     """Choose the compute device, honoring an explicit override."""
-    override = os.environ.get("TOKENPRINT_DEVICE", os.environ.get("NEUROSCOPE_DEVICE"))
+    override = os.environ.get("TOKENPRINT_DEVICE")
     if override:
         return override
     if torch.backends.mps.is_available():

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -46,8 +46,12 @@ from transformers import (
 from .debug import DebugCapture
 from .reduce import explained_variance, project_3d
 
-DEFAULT_MODEL_ID = os.environ.get("NEUROSCOPE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
-MAX_TOKENS = int(os.environ.get("NEUROSCOPE_MAX_TOKENS", "40"))
+DEFAULT_MODEL_ID = os.environ.get(
+    "TOKENPRINT_MODEL", os.environ.get("NEUROSCOPE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+)
+MAX_TOKENS = int(
+    os.environ.get("TOKENPRINT_MAX_TOKENS", os.environ.get("NEUROSCOPE_MAX_TOKENS", "40"))
+)
 
 # Rounding / thresholding for the attention payload.
 _ATTN_DECIMALS = 3
@@ -88,7 +92,7 @@ def _classify_model_type(model_type: str) -> str:
 
 def _pick_device() -> str:
     """Choose the compute device, honoring an explicit override."""
-    override = os.environ.get("NEUROSCOPE_DEVICE")
+    override = os.environ.get("TOKENPRINT_DEVICE", os.environ.get("NEUROSCOPE_DEVICE"))
     if override:
         return override
     if torch.backends.mps.is_available():

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic request/response models for the NeuroScope API.
+"""Pydantic request/response models for the TokenPrint API.
 
 Phase 1 covers tokens + the full attention tensor. Phase 2 fields
 (embeddings_3d, hidden_states_3d, projection) are added additively later.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-# NeuroScope backend dependencies.
+# TokenPrint backend dependencies.
 # torch / transformers / scikit-learn are pinned to the versions verified present
 # on this machine so behavior matches what was tested. The web stack is left
 # unpinned (latest is fine).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,7 +45,7 @@ Notes:
 - First boot downloads `Qwen/Qwen2.5-0.5B-Instruct` (~1GB) from Hugging Face;
   give it a persistent disk/cache or expect a cold-start download.
 - CPU is fine at this model size; no GPU required.
-- `NEUROSCOPE_MODEL` / `NEUROSCOPE_DEVICE` env vars override the model and device.
+- `TOKENPRINT_MODEL` / `TOKENPRINT_DEVICE` env vars override the model and device.
 
 ### 2. CORS
 

--- a/frontend/components/ui/DataExport.tsx
+++ b/frontend/components/ui/DataExport.tsx
@@ -22,7 +22,7 @@ export default function DataExport() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `neuroscope-${field}.json`;
+      a.download = `tokenprint-${field}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neuroscope-frontend",
+  "name": "tokenprint-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neuroscope-frontend",
+      "name": "tokenprint-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@react-three/drei": "^10.0.0",
@@ -674,6 +674,7 @@
       "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.63.0"
       },
@@ -752,6 +753,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -876,6 +878,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -910,6 +913,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.171.0.tgz",
       "integrity": "sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
@@ -1384,7 +1388,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -2020,6 +2025,7 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.39.2.tgz",
       "integrity": "sha512-AxPY+xFyVOsz+8bbHSyQBoOK4AUqSQspTXXIsNcKhmGJRm/afHRAwZ8bKC02AeSPII0PW6lbCN84SgAoWFsKKA==",
       "license": "Zlib",
+      "peer": true,
       "peerDependencies": {
         "three": ">= 0.168.0 < 0.186.0"
       }
@@ -2111,6 +2117,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2120,6 +2127,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2457,7 +2465,8 @@
       "version": "0.171.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
       "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neuroscope-frontend",
+  "name": "tokenprint-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/frontend/scripts/verify_ui.mjs
+++ b/frontend/scripts/verify_ui.mjs
@@ -101,7 +101,7 @@ async function main() {
 
   const s0 = await statusText(page);
   console.log("status @ load:", s0);
-  await page.screenshot({ path: `${OUT}/neuroscope_layer0_head0.png` });
+  await page.screenshot({ path: `${OUT}/tokenprint_layer0_head0.png` });
 
   const minWeight = 0.05; // store default
   const expA = expectedBeams(analyze.attention, 0, 0, minWeight);
@@ -117,7 +117,7 @@ async function main() {
   const s1 = await statusText(page);
   console.log("status @ switched:", s1);
   await page.screenshot({
-    path: `${OUT}/neuroscope_layer${targetLayer}_head${targetHead}.png`,
+    path: `${OUT}/tokenprint_layer${targetLayer}_head${targetHead}.png`,
   });
 
   const expB = expectedBeams(
@@ -157,7 +157,7 @@ async function main() {
     `page errors: ${errors.length}`,
     `result: ${ok ? "PASS" : "FAIL"}`,
   ];
-  writeFileSync(`${OUT}/neuroscope_ui_report.txt`, reportLines.join("\n"), "utf8");
+  writeFileSync(`${OUT}/tokenprint_ui_report.txt`, reportLines.join("\n"), "utf8");
 
   await browser.close();
   process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary
This PR rebrands all legacy `NeuroScope` / `neuroscope` / `NEUROSCOPE` references across the codebase to the official brand name **TokenPrint** / **tokenprint** / **TOKENPRINT**.

## Key Changes
- **Backend (`backend/app/`)**: Rebranded module docstrings in `__init__.py`, `main.py`, and `schemas.py`. Updated `FastAPI(title="TokenPrint")` and internal logger name to `tokenprint`.
- **Environment Variables (`backend/app/model.py`)**: Updated model and device override environment variables to `TOKENPRINT_MODEL`, `TOKENPRINT_MAX_TOKENS`, and `TOKENPRINT_DEVICE`.
- **Frontend (`frontend/`)**: Updated package name in `package.json` & `package-lock.json` to `tokenprint-frontend`. Updated export download filename in `DataExport.tsx` to `tokenprint-${field}.json`.
- **Testing & Tooling (`frontend/scripts/verify_ui.mjs`)**: Updated Playwright screenshot file paths and report output to `tokenprint_*`.
- **Documentation (`docs/deployment.md`, `backend/requirements.txt`)**: Updated deployment guide environment variables and file headers.

## Verification
- Verified zero (`0`) occurrences of legacy branding via codebase-wide grep search.
- Verified backend Python compilation with `python -m compileall backend/app`.
- Verified frontend static typing with `npx tsc --noEmit`.
