### PR TITLE
test: simulate stale contributor avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ Everyone below has a merged pull request in TokenPrint.
 <a href="https://github.com/Shivamyadav1312"><img src="https://github.com/Shivamyadav1312.png?size=96" alt="Shivamyadav1312" title="Shivamyadav1312" width="48" height="48" align="top" /></a>
 <a href="https://github.com/ris422"><img src="https://github.com/ris422.png?size=96" alt="ris422" title="ris422" width="48" height="48" align="top" /></a>
 <a href="https://github.com/Sriram-Selvaperumal"><img src="https://github.com/Sriram-Selvaperumal.png?size=96" alt="Sriram-Selvaperumal" title="Sriram-Selvaperumal" width="48" height="48" align="top" /></a>
-<a href="https://github.com/challenge456"><img src="https://github.com/challenge456.png?size=96" alt="challenge456" title="challenge456" width="48" height="48" align="top" /></a>
 </div>
 <!-- CONTRIBUTORS:END -->
 


### PR DESCRIPTION
Deliberate one-shot QA test: removes one avatar so the Update Contributors workflow regenerates it and proves the direct push to main bypasses branch protection via CONTRIBUTORS_TOKEN. Will be reverted by the bot itself.