### PR TITLE
ci: author contributor-auto-update commits as the repo owner

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -72,8 +72,10 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Author the commit as the repository owner so contributor updates land
+          # under their profile (pushing is already done with the owner's PAT).
+          git config user.name "Sudharsanselvaraj"
+          git config user.email "178299750+Sudharsanselvaraj@users.noreply.github.com"
           git add README.md
           git commit -m "chore: auto-update contributors in README"
 


### PR DESCRIPTION
The Update Contributors workflow now commits README updates under the repository owner's identity (`Sudharsanselvaraj` + the account's GitHub noreply email) instead of `github-actions[bot]`, so each auto-update counts toward the owner's contribution graph and links to the profile.