### PR TITLE
feat(backend): implement ModelAdapter capability abstraction (ENG-14)

### DIFF
--- a/backend/app/adapters.py
+++ b/backend/app/adapters.py
@@ -1,0 +1,83 @@
+"""Model Capability Adapter abstraction (ENG-14).
+
+Provides an extensible ModelAdapter interface and concrete adapter implementations
+for Causal LMs, Encoder embedding models, and Vision Transformers.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ModelAdapter(ABC):
+    """Abstract base class defining the capabilities and contracts for model architectures."""
+
+    mode: str = "generic"
+
+    @abstractmethod
+    def capabilities(self) -> dict[str, bool]:
+        """Return boolean feature capability flags supported by this model architecture."""
+        ...
+
+    def process_analysis(self, raw_output: dict[str, Any]) -> dict[str, Any]:
+        """Format and augment standard analysis payload with adapter capabilities."""
+        payload = dict(raw_output)
+        payload["capabilities"] = self.capabilities()
+        return payload
+
+
+class CausalLMAdapter(ModelAdapter):
+    """Adapter for decoder-only Causal Language Models (Qwen, Llama, Gemma, GPT-2)."""
+
+    mode: str = "causal_lm"
+
+    def capabilities(self) -> dict[str, bool]:
+        return {
+            "causal_generation": True,
+            "logit_lens": True,
+            "attention_maps": True,
+            "sentence_pooling": False,
+            "image_processing": False,
+        }
+
+
+class EncoderAdapter(ModelAdapter):
+    """Adapter for encoder-only embedding models (BERT, RoBERTa)."""
+
+    mode: str = "encoder"
+
+    def capabilities(self) -> dict[str, bool]:
+        return {
+            "causal_generation": False,
+            "logit_lens": False,
+            "attention_maps": True,
+            "sentence_pooling": True,
+            "image_processing": False,
+        }
+
+
+class VisionAdapter(ModelAdapter):
+    """Adapter for Vision Transformers (ViT, CLIP)."""
+
+    mode: str = "vision"
+
+    def capabilities(self) -> dict[str, bool]:
+        return {
+            "causal_generation": False,
+            "logit_lens": False,
+            "attention_maps": True,
+            "sentence_pooling": False,
+            "image_processing": True,
+        }
+
+
+def get_model_adapter(mode: str) -> ModelAdapter:
+    """Factory function returning the appropriate ModelAdapter for a given mode string."""
+    adapters: dict[str, type[ModelAdapter]] = {
+        "causal_lm": CausalLMAdapter,
+        "encoder": EncoderAdapter,
+        "vision": VisionAdapter,
+    }
+    adapter_cls = adapters.get(mode, CausalLMAdapter)
+    return adapter_cls()

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -43,6 +43,7 @@ from transformers import (
     DynamicCache,
 )
 
+from .adapters import get_model_adapter
 from .debug import DebugCapture
 from .reduce import explained_variance, project_3d
 
@@ -124,6 +125,7 @@ class ModelEngine:
         probe_cfg = AutoConfig.from_pretrained(model_id)
         self.model_type: str = str(getattr(probe_cfg, "model_type", "unknown"))
         self.mode: str = _classify_model_type(self.model_type)
+        self.adapter = get_model_adapter(self.mode)
 
         self.tokenizer: AutoTokenizer | None = None
         self.image_processor = None
@@ -372,8 +374,10 @@ class ModelEngine:
                 "use POST /analyze/image."
             )
         if self.mode == "encoder":
-            return self._analyze_encoder(sentence)
-        return self._analyze_causal_lm(sentence)
+            raw = self._analyze_encoder(sentence)
+        else:
+            raw = self._analyze_causal_lm(sentence)
+        return self.adapter.process_analysis(raw)
 
     def _analyze_causal_lm(self, sentence: str) -> dict:
         """Decoder-only causal LM forward pass (tokens, attention, geometry)."""

--- a/backend/tests/test_model_adapters.py
+++ b/backend/tests/test_model_adapters.py
@@ -1,0 +1,57 @@
+"""Unit tests for ModelAdapter capability abstractions (ENG-14).
+
+Verifies capabilities flags and analysis output augmentation across CausalLMAdapter,
+EncoderAdapter, and VisionAdapter architectures.
+"""
+
+from app.adapters import (
+    CausalLMAdapter,
+    EncoderAdapter,
+    VisionAdapter,
+    get_model_adapter,
+)
+
+
+def test_causal_lm_adapter_capabilities():
+    adapter = CausalLMAdapter()
+    caps = adapter.capabilities()
+    assert caps["causal_generation"] is True
+    assert caps["logit_lens"] is True
+    assert caps["attention_maps"] is True
+    assert caps["sentence_pooling"] is False
+    assert caps["image_processing"] is False
+
+    processed = adapter.process_analysis({"model": "test-causal"})
+    assert "capabilities" in processed
+    assert processed["capabilities"]["logit_lens"] is True
+
+
+def test_encoder_adapter_capabilities():
+    adapter = EncoderAdapter()
+    caps = adapter.capabilities()
+    assert caps["causal_generation"] is False
+    assert caps["logit_lens"] is False
+    assert caps["sentence_pooling"] is True
+    assert caps["image_processing"] is False
+
+
+def test_vision_adapter_capabilities():
+    adapter = VisionAdapter()
+    caps = adapter.capabilities()
+    assert caps["image_processing"] is True
+    assert caps["causal_generation"] is False
+
+
+def test_get_model_adapter_factory():
+    causal = get_model_adapter("causal_lm")
+    assert isinstance(causal, CausalLMAdapter)
+
+    encoder = get_model_adapter("encoder")
+    assert isinstance(encoder, EncoderAdapter)
+
+    vision = get_model_adapter("vision")
+    assert isinstance(vision, VisionAdapter)
+
+    # Fallback to CausalLMAdapter for unknown mode
+    unknown = get_model_adapter("unknown")
+    assert isinstance(unknown, CausalLMAdapter)


### PR DESCRIPTION
## Summary
Resolves **[ENG-14] Issue #114**. Introduces an extensible `ModelAdapter` capability abstraction layer in `backend/app/adapters.py` to standardize feature support flags and output processing across Causal LMs, Encoders, and Vision Transformers.

## Key Changes
- **`ModelAdapter` Hierarchy**: Added `ModelAdapter` abstract base class along with concrete `CausalLMAdapter`, `EncoderAdapter`, and `VisionAdapter` classes.
- **Factory & Engine Integration**: Added `get_model_adapter` factory function and integrated `self.adapter = get_model_adapter(self.mode)` into `ModelEngine`.
- **API Response Augmentation**: `analyze()` now automatically attaches a `"capabilities"` feature map (e.g. `logit_lens`, `sentence_pooling`, `image_processing`).
- **Unit Test Suite (`backend/tests/test_model_adapters.py`)**: Added dedicated tests for capability flags and adapter resolution (`4/4 passed`).

## Verification
- `python -m pytest tests/test_model_adapters.py` (4/4 passed).
- `python -m compileall backend/app` (100% clean compilation).
- `npx tsc --noEmit` (0 errors).
