### PR TITLE
fix(security): resolve CodeQL SSRF and log injection alerts in main.py (SEC-01)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -336,6 +336,53 @@ def hf_curated() -> dict:
     return {"models": []}
 
 
+def _sanitize_log_str(val: str) -> str:
+    """Sanitize user-supplied strings before logging to prevent CRLF log injection attacks."""
+    s = str(val or "")
+    return s.replace("\r", "").replace("\n", "")
+
+
+def _validate_ssrf_target_url(url: str) -> str:
+    """Validate target URL scheme, hostname, and IP range to prevent SSRF attacks.
+
+    Strictly enforces https://huggingface.co/ domain and checks resolved IP against
+    loopback, private, link-local, multicast, reserved, and unspecified ranges.
+    """
+    import ipaddress
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise HTTPException(status_code=400, detail="Only HTTPS URLs are allowed.")
+    if parsed.hostname != "huggingface.co" and not (parsed.hostname or "").endswith(".huggingface.co"):
+        raise HTTPException(status_code=400, detail="Only Hugging Face URLs are allowed.")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise HTTPException(status_code=400, detail="Missing URL hostname.")
+
+    try:
+        addr_info = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise HTTPException(status_code=502, detail=f"Hostname resolution failed: {exc}") from exc
+
+    for info in addr_info:
+        ip_str = info[4][0]
+        ip = ipaddress.ip_address(ip_str)
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise HTTPException(status_code=403, detail=f"Access to forbidden IP '{ip_str}' is denied.")
+
+    return url
+
+
 @app.get("/api/hf/search", response_model=HFSearchResponse)
 @app.get("/api/hf/search/", response_model=HFSearchResponse)
 def hf_search(query: str = "", limit: int = 10) -> HFSearchResponse:
@@ -356,6 +403,7 @@ def hf_search(query: str = "", limit: int = 10) -> HFSearchResponse:
     url = f"https://huggingface.co/api/models?limit={limit}&filter=text-generation"
     if query:
         url += f"&search={urllib.parse.quote(query)}"
+    url = _validate_ssrf_target_url(url)
 
     try:
         import json
@@ -391,7 +439,7 @@ def hf_search(query: str = "", limit: int = 10) -> HFSearchResponse:
             _hf_search_cache[cache_key] = (now, result)
             return result
     except (urllib.error.URLError, OSError, ValueError) as exc:
-        logger.warning(f"HF Hub search failed for '{query}': {exc}")
+        logger.warning(f"HF Hub search failed for '{_sanitize_log_str(query)}': {exc}")
         # Return empty search result fallback on error or network offline
         return HFSearchResponse(query=query, limit=limit, models=[])
 
@@ -415,7 +463,7 @@ def hf_inspect(model_id: str) -> HFInspectResponse:
         import urllib.request
 
         # 1. Fetch commit revision SHA metadata
-        meta_url = f"https://huggingface.co/api/models/{model_id}"
+        meta_url = _validate_ssrf_target_url(f"https://huggingface.co/api/models/{model_id}")
         meta_req = urllib.request.Request(
             meta_url,
             headers={"User-Agent": "TokenPrint/0.1.0"},
@@ -427,7 +475,7 @@ def hf_inspect(model_id: str) -> HFInspectResponse:
                 revision = meta_json.get("sha") or meta_json.get("revision") or "main"
 
         # 2. Fetch config.json
-        config_url = f"https://huggingface.co/{model_id}/raw/main/config.json"
+        config_url = _validate_ssrf_target_url(f"https://huggingface.co/{model_id}/raw/main/config.json")
         cfg_req = urllib.request.Request(
             config_url,
             headers={"User-Agent": "TokenPrint/0.1.0"},
@@ -468,8 +516,8 @@ def hf_inspect(model_id: str) -> HFInspectResponse:
     except HTTPException:
         raise
     except Exception as exc:
-        logger.error(f"HF inspection error for '{model_id}': {exc}")
-        raise HTTPException(status_code=500, detail=f"Failed to inspect model '{model_id}': {exc}") from exc
+        logger.error(f"HF inspection error for '{_sanitize_log_str(model_id)}': {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to inspect model '{_sanitize_log_str(model_id)}': {exc}") from exc
 
 
 @app.get("/api/model/capabilities")

--- a/backend/tests/test_codeql_sec.py
+++ b/backend/tests/test_codeql_sec.py
@@ -1,0 +1,53 @@
+"""Unit tests for CodeQL security alert fixes (SEC-01).
+
+Verifies SSRF URL validation and log injection sanitization in backend/app/main.py.
+"""
+
+from unittest import mock
+import pytest
+from fastapi import HTTPException
+
+from app.main import _sanitize_log_str, _validate_ssrf_target_url
+
+
+def test_sanitize_log_str_removes_crlf():
+    """Verify _sanitize_log_str removes carriage returns and newlines."""
+    malicious_input = "query\r\nINFO:fake_user logged in\n"
+    sanitized = _sanitize_log_str(malicious_input)
+    assert "\r" not in sanitized
+    assert "\n" not in sanitized
+    assert sanitized == "queryINFO:fake_user logged in"
+
+
+def test_validate_ssrf_target_url_valid_hf():
+    """Verify valid HuggingFace URLs pass validation."""
+    valid_url = "https://huggingface.co/api/models?limit=10"
+    with mock.patch("socket.getaddrinfo") as mock_dns:
+        # Mock public IP address (e.g. 54.235.210.123)
+        mock_dns.return_value = [(None, None, None, None, ("54.235.210.123", 443))]
+        res = _validate_ssrf_target_url(valid_url)
+        assert res == valid_url
+
+
+def test_validate_ssrf_target_url_blocks_http():
+    """Verify non-HTTPS URLs are rejected."""
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_ssrf_target_url("http://huggingface.co/api/models")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_ssrf_target_url_blocks_unauthorized_domain():
+    """Verify non-HuggingFace domains are rejected."""
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_ssrf_target_url("https://malicious-site.com/api/models")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_ssrf_target_url_blocks_private_ip():
+    """Verify URLs resolving to private or loopback IPs are blocked."""
+    with mock.patch("socket.getaddrinfo") as mock_dns:
+        # Mock internal loopback IP 127.0.0.1
+        mock_dns.return_value = [(None, None, None, None, ("127.0.0.1", 443))]
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_ssrf_target_url("https://huggingface.co/api/models")
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
Resolves **[SEC-01] Issue #160**. Closes all 5 CodeQL error-tier alerts on `main` (3 SSRF vulnerability warnings + 2 CRLF log injection warnings) in `backend/app/main.py`.

## Key Changes
- **SSRF Hardening**: Added `_validate_ssrf_target_url` helper in `main.py` enforcing `https://huggingface.co/` domain restrictions and resolving target IPs against forbidden ranges (loopback, private, link-local, multicast, reserved). Applied to lines 364, 419, and 431.
- **Log Injection Hardening**: Added `_sanitize_log_str` helper stripping `\r` and `\n` characters from user-supplied inputs before passing to logger statements. Applied to lines 394 and 471.
- **Security Unit Tests (`backend/tests/test_codeql_sec.py`)**: Added test suite validating SSRF IP blocking, scheme enforcement, and CRLF log sanitization (`5/5 passed`).

## Verification
- `python -m pytest tests/test_codeql_sec.py` (5/5 passed).
- `python -m compileall backend/app` (100% clean compilation).
- `npx tsc --noEmit` (0 errors).
