### PR TITLE
doc(branding): sweep remaining NeuroScope references to TokenPrint (DOC-08)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-"""NeuroScope backend — FastAPI service serving REAL language-model internals.
+"""TokenPrint backend — FastAPI service serving REAL language-model internals.
 
 Every value this package emits (attention weights, hidden-state stats, logits)
 comes from an actual forward pass of a real open-weight model. Nothing here is

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-"""FastAPI application for NeuroScope.
+"""FastAPI application for TokenPrint.
 
 Endpoints:
   * GET  /health      — liveness + whether the model is loaded
@@ -51,7 +51,7 @@ from .schemas import (
 from .trace import TraceRecorder, parse_trace, serialize_trace
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("neuroscope")
+logger = logging.getLogger("tokenprint")
 
 # Single process-wide engine handle, populated in the lifespan handler.
 engine: ModelEngine | None = None
@@ -106,7 +106,7 @@ async def lifespan(app: FastAPI):
     engine = None
 
 
-app = FastAPI(title="NeuroScope", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="TokenPrint", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -46,8 +46,8 @@ from transformers import (
 from .debug import DebugCapture
 from .reduce import explained_variance, project_3d
 
-DEFAULT_MODEL_ID = os.environ.get("NEUROSCOPE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
-MAX_TOKENS = int(os.environ.get("NEUROSCOPE_MAX_TOKENS", "40"))
+DEFAULT_MODEL_ID = os.environ.get("TOKENPRINT_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+MAX_TOKENS = int(os.environ.get("TOKENPRINT_MAX_TOKENS", "40"))
 
 # Rounding / thresholding for the attention payload.
 _ATTN_DECIMALS = 3
@@ -88,7 +88,7 @@ def _classify_model_type(model_type: str) -> str:
 
 def _pick_device() -> str:
     """Choose the compute device, honoring an explicit override."""
-    override = os.environ.get("NEUROSCOPE_DEVICE")
+    override = os.environ.get("TOKENPRINT_DEVICE")
     if override:
         return override
     if torch.backends.mps.is_available():

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic request/response models for the NeuroScope API.
+"""Pydantic request/response models for the TokenPrint API.
 
 Phase 1 covers tokens + the full attention tensor. Phase 2 fields
 (embeddings_3d, hidden_states_3d, projection) are added additively later.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-# NeuroScope backend dependencies.
+# TokenPrint backend dependencies.
 # torch / transformers / scikit-learn are pinned to the versions verified present
 # on this machine so behavior matches what was tested. The web stack is left
 # unpinned (latest is fine).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,7 +45,7 @@ Notes:
 - First boot downloads `Qwen/Qwen2.5-0.5B-Instruct` (~1GB) from Hugging Face;
   give it a persistent disk/cache or expect a cold-start download.
 - CPU is fine at this model size; no GPU required.
-- `NEUROSCOPE_MODEL` / `NEUROSCOPE_DEVICE` env vars override the model and device.
+- `TOKENPRINT_MODEL` / `TOKENPRINT_DEVICE` env vars override the model and device.
 
 ### 2. CORS
 

--- a/frontend/components/ui/DataExport.tsx
+++ b/frontend/components/ui/DataExport.tsx
@@ -22,7 +22,7 @@ export default function DataExport() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `neuroscope-${field}.json`;
+      a.download = `tokenprint-${field}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neuroscope-frontend",
+  "name": "tokenprint-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neuroscope-frontend",
+      "name": "tokenprint-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@react-three/drei": "^10.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neuroscope-frontend",
+  "name": "tokenprint-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/frontend/scripts/verify_ui.mjs
+++ b/frontend/scripts/verify_ui.mjs
@@ -101,7 +101,7 @@ async function main() {
 
   const s0 = await statusText(page);
   console.log("status @ load:", s0);
-  await page.screenshot({ path: `${OUT}/neuroscope_layer0_head0.png` });
+  await page.screenshot({ path: `${OUT}/tokenprint_layer0_head0.png` });
 
   const minWeight = 0.05; // store default
   const expA = expectedBeams(analyze.attention, 0, 0, minWeight);
@@ -117,7 +117,7 @@ async function main() {
   const s1 = await statusText(page);
   console.log("status @ switched:", s1);
   await page.screenshot({
-    path: `${OUT}/neuroscope_layer${targetLayer}_head${targetHead}.png`,
+    path: `${OUT}/tokenprint_layer${targetLayer}_head${targetHead}.png`,
   });
 
   const expB = expectedBeams(
@@ -157,7 +157,7 @@ async function main() {
     `page errors: ${errors.length}`,
     `result: ${ok ? "PASS" : "FAIL"}`,
   ];
-  writeFileSync(`${OUT}/neuroscope_ui_report.txt`, reportLines.join("\n"), "utf8");
+  writeFileSync(`${OUT}/tokenprint_ui_report.txt`, reportLines.join("\n"), "utf8");
 
   await browser.close();
   process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary
Resolves **[DOC-08] Issue #165**. Performs a full repository-wide consistency sweep replacing all remaining legacy `NeuroScope` / `neuroscope` / `NEUROSCOPE` references with the official brand name **TokenPrint**.

## Key Changes
- **Backend**: Updated module docstrings in `__init__.py`, `main.py`, `schemas.py`, and `requirements.txt`. Rebranded FastAPI title to `TokenPrint` and logger to `tokenprint`.
- **Environment Variables**: Rebranded model and device environment variable overrides in `model.py` and `docs/deployment.md` to `TOKENPRINT_MODEL`, `TOKENPRINT_MAX_TOKENS`, and `TOKENPRINT_DEVICE`.
- **Frontend & Tooling**: Rebranded package name in `package.json` and `package-lock.json` to `tokenprint-frontend`. Updated default JSON export download name in `DataExport.tsx` and Playwright screenshot outputs in `verify_ui.mjs` to `tokenprint_*`.

## Verification
- Codebase-wide grep: `0` remaining references to legacy name.
- `python -m compileall backend/app` (100% clean compilation).
- `npx tsc --noEmit` (0 errors).
