### PR TITLE
feat: serve site at tokenprint.in custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,12 @@ jobs:
         run: |
           curl -s https://api.github.com/repos/${{ github.repository }}/contributors?per_page=100 > public/contributors.json || echo "[]" > public/contributors.json
 
+      # Serve at the domain root (tokenprint.in) instead of /Token-Print.
+      # NEXT_DISABLE_BASEPATH opts out of the basePath derived from
+      # GITHUB_REPOSITORY (which GitHub pre-sets as a read-only override).
       - run: npm run build
+        env:
+          NEXT_DISABLE_BASEPATH: "1"
 
       - name: Skip deploy when Pages is disabled
         if: ${{ github.event.repository.has_pages != true }}

--- a/frontend/public/CNAME
+++ b/frontend/public/CNAME
@@ -1,0 +1,1 @@
+tokenprint.in


### PR DESCRIPTION
Configures GitHub Pages to serve at `tokenprint.in`:
- adds `frontend/public/CNAME` (copied into `out/` by the static export)
- builds the export with `NEXT_DISABLE_BASEPATH=1` so content is served at the domain root instead of `/Token-Print`

Deployment side is ready; DNS records still need to be pointed at GitHub Pages in GoDaddy.